### PR TITLE
Android Gradle Plugin 8 support

### DIFF
--- a/hl_image_picker_android/android/build.gradle
+++ b/hl_image_picker_android/android/build.gradle
@@ -25,6 +25,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.howl.hl_image_picker'
+    }
+    
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
Adds a namespace attribute to the Android build.gradle, for compatibility with Android Gradle Plugin 8.0.
See:
https://github.com/flutter/packages/commit/6284c2d4e46a5d289e77cb03a9457543b97f750b